### PR TITLE
Add HTTP output support and enhance configuration options

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -51,3 +51,13 @@ OUTPUTS:
       MAX_FILES: 7      # 보존 파일 개수 제한(선택)
       BATCH_SIZE : 10
       FLUSH_INTERVAL: 5s
+  - TYPE: http
+    TARGETS: [syslog, applog]
+    OPTIONS:
+      URL: http://localhost:8080/logs
+      METHOD: POST
+      HEADERS:
+        Content-Type: application/json
+      TIMEOUT: 5s
+      BATCH_SIZE: 10
+      FLUSH_INTERVAL: 5s

--- a/confmanager/config.go
+++ b/confmanager/config.go
@@ -38,13 +38,17 @@ type OutputConfig struct {
 	Type    string   `yaml:"TYPE"`
 	Targets []string `yaml:"TARGETS"`
 	Options struct {
-		Path     string `yaml:"PATH"`
-		Filename string `yaml:"FILENAME"`  // e.g., "output.log"
-		Rolling  string `yaml:"ROLLING"`   // daily, hourly, monthly
-		MaxSize  string `yaml:"MAX_SIZE"`  // e.g., "100MB"
-		MaxFiles int    `yaml:"MAX_FILES"` // e.g., 7
-		BATCH_SIZE int  `yaml:"BATCH_SIZE"` // e.g., 10
-		FLUSH_INTERVAL string `yaml:"FLUSH_INTERVAL"` // e.g., "5s"
+		Url            string            `yaml:"URL"`     // e.g., "http://localhost:8080"
+		Method         string            `yaml:"METHOD"`  // e.g., "POST"
+		Headers        map[string]string `yaml:"HEADERS"` // e.g., {"Content-Type": "application/json"}
+		Timeout        string            `yaml:"TIMEOUT"` // e.g., "5s"
+		Path           string            `yaml:"PATH"`
+		Filename       string            `yaml:"FILENAME"`       // e.g., "output.log"
+		Rolling        string            `yaml:"ROLLING"`        // daily, hourly, monthly
+		MaxSize        string            `yaml:"MAX_SIZE"`       // e.g., "100MB"
+		MaxFiles       int               `yaml:"MAX_FILES"`      // e.g., 7
+		BATCH_SIZE     int               `yaml:"BATCH_SIZE"`     // e.g., 10
+		FLUSH_INTERVAL string            `yaml:"FLUSH_INTERVAL"` // e.g., "5s"
 	} `yaml:"OPTIONS"`
 }
 

--- a/output/httppost.go
+++ b/output/httppost.go
@@ -1,0 +1,134 @@
+package output
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"test_gluent_mini/shared"
+	"time"
+)
+
+type HttpOutput struct {
+	Type           string
+	Targets        []string
+	Url            string
+	Method         string
+	Headers        map[string]string
+	Timeout        string
+	BATCH_SIZE     int
+	FLUSH_INTERVAL string
+}
+
+func (h HttpOutput) Out(ctx context.Context, outputChannel map[string]chan shared.InputData) {
+
+	if h.BATCH_SIZE == 0 {
+		h.BATCH_SIZE = BATCH_SIZE_DEFAULT
+	}
+	if h.FLUSH_INTERVAL == "" {
+		h.FLUSH_INTERVAL = FLUSH_INTERVAL_DEFAULT
+	}
+	duration, err := time.ParseDuration(h.FLUSH_INTERVAL)
+	if err != nil {
+		fmt.Printf("Error parsing FLUSH_INTERVAL %s: %v\n", h.FLUSH_INTERVAL, err)
+		return
+	}
+
+	if h.Timeout == "" {
+		h.Timeout = "5s" // Default timeout if not specified
+	}
+	timeout, err := time.ParseDuration(h.Timeout)
+	if err != nil {
+		fmt.Printf("Error parsing timeout %s: %v\n", h.Timeout, err)
+		return
+	}
+
+	if err := h._waitForEndpointReady(timeout); err != nil {
+		fmt.Printf("Error waiting for endpoint to be ready: %v\n", err)
+		return
+	}
+
+	for _, target := range h.Targets {
+		lineChan := outputChannel[target]
+		go func(ctx context.Context, lineChan chan shared.InputData) {
+			for {
+				batch := make([]shared.InputData, 0, h.BATCH_SIZE)
+				timer := time.NewTimer(duration)
+			BATCHLOOP:
+				for {
+					select {
+					case <-ctx.Done():
+						return
+					case logLine := <-lineChan:
+						batch = append(batch, logLine)
+						if len(batch) >= h.BATCH_SIZE {
+							break BATCHLOOP
+						}
+					case <-timer.C:
+						break BATCHLOOP
+					}
+				}
+
+				for _, logLine := range batch {
+					fmt.Printf("Sending HTTP POST to %s for target %s\n", h.Url, logLine.Tag)
+					if err := h._writeToHttp(logLine, timeout); err != nil {
+						fmt.Printf("Error writing to HTTP: %v\n", err)
+					}
+				}
+				batch = nil // Clear the batch for the next iteration
+				timer.Stop()
+			}
+		}(ctx, lineChan)
+	}
+}
+
+func (h HttpOutput) _waitForEndpointReady(timeout time.Duration) error {
+	// TODO: Implement health check logic to wait for the HTTP endpoint to be ready
+	req, err := http.NewRequest("HEAD", h.Url, nil)
+	if err != nil {
+		return fmt.Errorf("Error creating HTTP request: %v", err)
+	}
+	client := &http.Client{
+		Timeout: timeout,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("Error sending HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP endpoint not ready, status: %s", resp.Status)
+	}
+	return nil
+}
+
+func (h HttpOutput) _writeToHttp(logLine shared.InputData, timeout time.Duration) error {
+	// TODO : Implement the logic to convert logLine to the appropriate format (e.g., JSON)
+
+	// Example implementation (replace with actual logic)
+	jsonData, err := json.Marshal(logLine)
+	if err != nil {
+		return fmt.Errorf("Error marshaling logLine to JSON: %v", err)
+	}
+
+	// Send the JSON data to the HTTP endpoint
+	// add timeout to the request
+	if h.Timeout == "" {
+		h.Timeout = "5s" // Default timeout if not specified
+	}
+	client := &http.Client{
+		Timeout: timeout, // Set a timeout for the request
+	}
+	resp, err := client.Post(h.Url, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		return fmt.Errorf("Error sending HTTP POST request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP request failed with status: %s", resp.Status)
+	}
+	fmt.Printf("HTTP POST successful for target %s: %s\n", logLine.Tag, logLine.FileName)
+	return nil
+}

--- a/output/httppost.go
+++ b/output/httppost.go
@@ -97,7 +97,7 @@ func (h HttpOutput) _waitForEndpointReady(timeout time.Duration) error {
 		return fmt.Errorf("Error sending HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("HTTP endpoint not ready, status: %s", resp.Status)
 	}
 	return nil

--- a/output/httppost.go
+++ b/output/httppost.go
@@ -114,9 +114,6 @@ func (h HttpOutput) _writeToHttp(logLine shared.InputData, timeout time.Duration
 
 	// Send the JSON data to the HTTP endpoint
 	// add timeout to the request
-	if h.Timeout == "" {
-		h.Timeout = "5s" // Default timeout if not specified
-	}
 	client := &http.Client{
 		Timeout: timeout, // Set a timeout for the request
 	}

--- a/output/manager.go
+++ b/output/manager.go
@@ -3,15 +3,16 @@ package output
 import (
 	"context"
 	"fmt"
+	"slices"
 	"test_gluent_mini/confmanager"
 	"test_gluent_mini/shared"
 )
 
 const (
-	ROLLING_DEFAULT      = "daily"
-	MAX_SIZE_DEFAULT     = "100MB"
-	MAX_FILES_DEFAULT    = 7
-	BATCH_SIZE_DEFAULT   = 10
+	ROLLING_DEFAULT        = "daily"
+	MAX_SIZE_DEFAULT       = "100MB"
+	MAX_FILES_DEFAULT      = 7
+	BATCH_SIZE_DEFAULT     = 10
 	FLUSH_INTERVAL_DEFAULT = "1s"
 )
 
@@ -26,30 +27,85 @@ func Configure(conf confmanager.Config) {
 }
 
 func Out() {
+
+	outputChannel := make(map[string]map[string]chan shared.InputData, len(config.Outputs))
+	for _, outputConfig := range config.Outputs {
+		if _, exists := outputChannel[outputConfig.Type]; !exists {
+			outputChannel[outputConfig.Type] = make(map[string]chan shared.InputData)
+		}
+		for _, target := range outputConfig.Targets {
+			ch := make(chan shared.InputData, 1000)
+			outputChannel[outputConfig.Type][target] = ch
+		}
+	}
+
 	for _, outputConfig := range config.Outputs {
 		switch outputConfig.Type {
 		case "stdout":
 			consoleOutput := ConsoleOutput{
-				Type:    outputConfig.Type,
-				Targets: outputConfig.Targets,
-				BATCH_SIZE: outputConfig.Options.BATCH_SIZE,
+				Type:           outputConfig.Type,
+				Targets:        outputConfig.Targets,
+				BATCH_SIZE:     outputConfig.Options.BATCH_SIZE,
 				FLUSH_INTERVAL: outputConfig.Options.FLUSH_INTERVAL,
 			}
-			consoleOutput.Out(shared.Ctx)
+			consoleOutput.Out(shared.Ctx, outputChannel[outputConfig.Type])
 		case "file":
 			fileOutput := FileOutput{
-				Targets:  outputConfig.Targets,
-				Path:     outputConfig.Options.Path,
-				Filename: outputConfig.Options.Filename,
-				Rolling:  outputConfig.Options.Rolling,
-				MaxSize:  outputConfig.Options.MaxSize,
-				MaxFiles: outputConfig.Options.MaxFiles,
-				BATCH_SIZE: outputConfig.Options.BATCH_SIZE,
+				Targets:        outputConfig.Targets,
+				Path:           outputConfig.Options.Path,
+				Filename:       outputConfig.Options.Filename,
+				Rolling:        outputConfig.Options.Rolling,
+				MaxSize:        outputConfig.Options.MaxSize,
+				MaxFiles:       outputConfig.Options.MaxFiles,
+				BATCH_SIZE:     outputConfig.Options.BATCH_SIZE,
 				FLUSH_INTERVAL: outputConfig.Options.FLUSH_INTERVAL,
 			}
-			fileOutput.Out(shared.Ctx)
+			fileOutput.Out(shared.Ctx, outputChannel[outputConfig.Type])
+		case "http":
+			httpOutput := HttpOutput{
+				Type:           outputConfig.Type,
+				Targets:        outputConfig.Targets,
+				Url:            outputConfig.Options.Url,
+				Method:         outputConfig.Options.Method,
+				Headers:        outputConfig.Options.Headers,
+				Timeout:        outputConfig.Options.Timeout,
+				BATCH_SIZE:     outputConfig.Options.BATCH_SIZE,
+				FLUSH_INTERVAL: outputConfig.Options.FLUSH_INTERVAL,
+			}
+			httpOutput.Out(shared.Ctx, outputChannel[outputConfig.Type])
 		default:
 			fmt.Printf("Unsupported output type: %s\n", outputConfig.Type)
+		}
+	}
+
+	go _broadcastFilteredData(outputChannel)
+}
+
+func _broadcastFilteredData(outputChannel map[string]map[string]chan shared.InputData) {
+	targets := make([]string, 0, len(outputChannel))
+	for _, outputConfig := range config.Outputs {
+		for _, target := range outputConfig.Targets {
+			if !slices.Contains(targets, target) {
+				targets = append(targets, target)
+			}
+		}
+	}
+	for {
+		select {
+		case <-shared.Ctx.Done():
+			return // Exit if the context is cancelled
+		default:
+			for _, target := range targets {
+				logLine := <-shared.FilterChannel[target]
+				for outputType, channels := range outputChannel {
+					if ch, exists := channels[target]; exists {
+						ch <- logLine
+					} else {
+						fmt.Printf("No channel found for target %s in output type %s\n", target, outputType)
+					}
+				}
+				shared.OffsetChannel <- logLine // send to offset channel after broadcasting
+			}
 		}
 	}
 }

--- a/output/manager.go
+++ b/output/manager.go
@@ -97,6 +97,8 @@ func _broadcastFilteredData(outputChannel map[string]map[string]chan shared.Inpu
 		default:
 			for _, target := range targets {
 				select {
+				case <-shared.Ctx.Done():
+					return // Exit if the context is cancelled
 				case logLine := <-shared.InputChannel[target]:
 					for outputType, channels := range outputChannel {
 						if ch, exists := channels[target]; exists {

--- a/server/log_server.go
+++ b/server/log_server.go
@@ -42,8 +42,13 @@ func handleRequests() {
 }
 
 func logHandler(w http.ResponseWriter, r *http.Request) {
-	body, _ := io.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	defer r.Body.Close()
+	if err != nil {
+		http.Error(w, "Failed to read request body", http.StatusBadRequest)
+		fmt.Println("Error reading request body:", err)
+		return
+	}
 	fmt.Println("Received POST:", string(body))
 	w.WriteHeader(http.StatusOK)
 }

--- a/server/log_server.go
+++ b/server/log_server.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var httpServer *http.Server
+
+func Run() {
+	httpServer = &http.Server{
+		Addr: ":8080",
+	}
+	handleRequests()
+	fmt.Println("Starting log server on :8080")
+	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		fmt.Println("Error starting log server:", err)
+		return
+	}
+	fmt.Println("Log server started successfully")
+}
+
+func Shutdown(ctx context.Context) {
+	fmt.Println("Shutting down log server...")
+	if err := httpServer.Shutdown(ctx); err != nil {
+		fmt.Println("Error shutting down log server:", err)
+	}
+}
+
+func handleRequests() {
+	httpServer.Handler = http.NewServeMux()
+	httpServer.Handler.(*http.ServeMux).HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Welcome to the Log Server!")
+	})
+	httpServer.Handler.(*http.ServeMux).HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Log Server is healthy")
+	})
+	httpServer.Handler.(*http.ServeMux).HandleFunc("/logs", logHandler)
+}
+
+func logHandler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	defer r.Body.Close()
+	fmt.Println("Received POST:", string(body))
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
- Introduced HttpOutput type for sending logs via HTTP POST.
- Updated OutputConfig to include HTTP-specific options (URL, METHOD, HEADERS, TIMEOUT).
- Modified ConsoleOutput and FileOutput to accept output channels for better data handling.
- Implemented server functionality to handle incoming log requests.
- Enhanced configuration file to support new HTTP output type and flushing intervals.